### PR TITLE
fix: drop funsion-inspector from download-singularity-img.nf

### DIFF
--- a/download-singularity-img.nf
+++ b/download-singularity-img.nf
@@ -63,7 +63,6 @@ if (params.fusioncatcher || params.download_all) running_tools.add("Fusioncatche
 if (params.ericscript || params.download_all) running_tools.add("Ericscript")
 if (params.pizzly || params.download_all) running_tools.add("Pizzly")
 if (params.squid || params.download_all) running_tools.add("Squid")
-if (params.fusion_inspector || params.download_all) running_tools.add("Fusion-Inspector")
 
 // Header log info
 log.info nfcoreHeader()
@@ -145,21 +144,6 @@ process download_fusioncatcher {
     script:
     """
     singularity pull --name nf-core-rnafusion-fusioncatcher_${params.versions.fusioncatcher}.img docker://nfcore/rnafusion:fusioncatcher_${params.versions.fusioncatcher}
-    """
-}
-
-process download_fusion_inspector {
-    publishDir "${params.outdir}", mode: 'copy'
-    
-    when:
-    params.fusion_inspector || params.download_all
-
-    output:
-    file "nf-core-rnafusion-fusion-inspector_${params.versions.fusion_inspector}.img"
-
-    script:
-    """
-    singularity pull --name nf-core-rnafusion-fusion-inspector_${params.versions.fusion_inspector}.img docker://nfcore/rnafusion:fusion-inspector_${params.versions.fusion_inspector}
     """
 }
 

--- a/scripts/download-singularity-img.sh
+++ b/scripts/download-singularity-img.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_tool_version() {
-    echo $(cat nextflow.config | grep -m1 "$1" | cut -d"=" -f2 | tr -d \' | tr -d ' ')
+    echo $(cat conf/base.config | grep -m1 "$1" | cut -d"=" -f2 | tr -d \' | tr -d ' ')
 }
 
 if [ $# -eq 0 ]; then
@@ -28,7 +28,6 @@ elif [ -d "$1" ]; then
     STAR_FUSION=$(get_tool_version "star_fusion")
 
     cd $1 && echo "Pulling images ..."
-
     singularity pull --name "${PREFIX}-arriba_${ARRIBA}.img" docker://nfcore/rnafusion:arriba_${ARRIBA}
     singularity pull --name "${PREFIX}-ericscript_${ERICSCRIPT}.img" docker://nfcore/rnafusion:ericscript_${ERICSCRIPT}
     singularity pull --name "${PREFIX}-fusioncatcher_${FUSIONCATCHER}.img" docker://nfcore/rnafusion:fusioncatcher_${FUSIONCATCHER}


### PR DESCRIPTION
Removed fusion-inspector from `download-singularity-img.nf`