### PR TITLE
Adding log extension to outputs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -719,7 +719,7 @@ process fusion_inspector {
         file(reference) from reference.fusion_inspector
 
     output:
-        file("*.{fa,gtf,bed,bam,bai,txt,html}") into fusion_inspector_output
+        file("*.{fa,gtf,bed,bam,bai,txt,html,log}") into fusion_inspector_output
 
     when: params.fusion_inspector && (!params.single_end || params.debug)
 


### PR DESCRIPTION
# nf-core/rnafusion pull request

- Description of changes (with reason)

FusionInspector was crashing the NF exec if one sample have 0 fusions in any software, because it creates none of the expected file extensions of the output channel.
A quick fix is to add the log to the extensions. Maybe it could be better to have an optional output there?

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/rnafusion branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/rnafusion)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)