### PR TITLE
Squid ensembl ref

### DIFF
--- a/subworkflows/local/squid_workflow.nf
+++ b/subworkflows/local/squid_workflow.nf
@@ -10,7 +10,7 @@ workflow SQUID_WORKFLOW {
     take:
         reads
         ch_gtf
-        ch_starindex_ref
+        ch_starindex_ensembl_ref
 
     main:
         ch_versions = Channel.empty()
@@ -21,7 +21,7 @@ workflow SQUID_WORKFLOW {
                 ch_squid_fusions = GET_META(reads, params.squid_fusions)
             } else {
 
-            STAR_FOR_SQUID( reads, ch_starindex_ref, ch_gtf, params.star_ignore_sjdbgtf, params.seq_platform, params.seq_center )
+            STAR_FOR_SQUID( reads, ch_starindex_ensembl_ref, ch_gtf, params.star_ignore_sjdbgtf, params.seq_platform, params.seq_center )
             ch_versions = ch_versions.mix(STAR_FOR_SQUID.out.versions )
 
             SAMTOOLS_VIEW_FOR_SQUID ( STAR_FOR_SQUID.out.sam, [] )

--- a/workflows/rnafusion.nf
+++ b/workflows/rnafusion.nf
@@ -16,6 +16,7 @@ if (file(params.input).exists() || params.build_references) { ch_input = file(pa
 
 ch_chrgtf = params.starfusion_build ? file(params.chrgtf) : file("${params.starfusion_ref}/ref_annot.gtf")
 ch_starindex_ref = params.starfusion_build ? params.starindex_ref : "${params.starfusion_ref}/ref_genome.fa.star.idx"
+ch_starindex_ensembl_ref = params.starindex_ref
 ch_refflat = params.starfusion_build ? file(params.refflat) : "${params.ensembl_ref}/ref_annot.gtf.refflat"
 
 def checkPathParamList = [
@@ -160,7 +161,7 @@ workflow RNAFUSION {
     SQUID_WORKFLOW (
         ch_cat_fastq,
         ch_gtf,
-        ch_starindex_ref
+        ch_starindex_ensembl_ref
     )
     ch_versions = ch_versions.mix(SQUID_WORKFLOW.out.versions.first().ifEmpty(null))
 


### PR DESCRIPTION
Squid can only annotate properly when using ensembl gtf and not the gencode gtf used for STARfusion and arriba. This reverts squid to use ensembl