### PR TITLE
Update usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,7 +66,7 @@ nextflow run nf-core/rnafusion \
   --genomes_base <REFERENCE_PATH>
 ```
 
-`--genomes_base` should point to the `references/` subdirectory of the path of the outdir from step 1 `build_references`.
+`--genomes_base` should be the path to the directory containing the folder `references/` that was built in step 1 `build_references`.
 
 Alternatively, to run only a specific detection tool specify with `--tool`:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,6 +66,8 @@ nextflow run nf-core/rnafusion \
   --genomes_base <REFERENCE_PATH>
 ```
 
+`--genomes_base` should point to the `references/` subdirectory of the path of the outdir from step 1 `build_references`.
+
 Alternatively, to run only a specific detection tool specify with `--tool`:
 
 ```bash


### PR DESCRIPTION
genomes_base needs to point to the references subdirectory from the build_references path. This does seem inconsistent. REFERENCE_PATH from Steps 1 and 2 should ideally be the same.
