### PR TITLE
Update of single-end recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Arriba use ensembl references-built starindex independently of starfusion_build parameter
+- Update of the single-end reads support table in README, added recommendation to use single-end reads only in last resort
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `FusionCatcher` single_end support for single reads ABOVE 130 bp
 ### Changed
 
 - Arriba use ensembl references-built starindex independently of starfusion_build parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `FusionCatcher` single_end support for single reads ABOVE 130 bp
+
 ### Changed
 
 - Arriba use ensembl references-built starindex independently of starfusion_build parameter
 - Update of the single-end reads support table in README, added recommendation to use single-end reads only in last resort
-
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 | --------------------------------------------------------- | :----------------: | :------: |
 | [Arriba](https://github.com/suhrig/arriba)                |        :x:         | `2.2.1`  |
 | [FusionCatcher](https://github.com/ndaniel/fusioncatcher) | :white_check_mark: |  `1.33`  |
-| [Fusion-report](https://github.com/matq007/fusion-report) |         -          | `2.1.5`  |
 | [Pizzly](https://github.com/pmelsted/pizzly)              |        :x:         | `0.37.3` |
 | [Squid](https://github.com/Kingsford-Group/squid)         |        :x:         |  `1.5`   |
 | [STAR-Fusion](https://github.com/STAR-Fusion/STAR-Fusion) | :white_check_mark: | `1.10.1` |
+
+> Single-end reads are to be use as last-resort. Paired-end reads are recommended. FusionCatcher cannot be used with single-end reads shorter than 130 bp.
 
 On release, automated continuous integration tests run the pipeline on a full-sized dataset on the AWS cloud infrastructure. This ensures that the pipeline runs on AWS, has sensible resource allocation defaults set to run on real-world datasets, and permits the persistent storage of results to benchmark between pipeline releases and other analysis sources. The results obtained from the full-sized test can be viewed on the [nf-core website](https://nf-co.re/rnafusion/results).
 

--- a/modules/local/fusioncatcher/detect/main.nf
+++ b/modules/local/fusioncatcher/detect/main.nf
@@ -26,6 +26,7 @@ process FUSIONCATCHER {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def reads = fasta.toString().replace(" ", ",")
+    def single_end = meta.single_end ? "--single-end" : ""
     """
     fusioncatcher.py \\
         -d $reference \\
@@ -33,6 +34,7 @@ process FUSIONCATCHER {
         -p $task.cpus \\
         -o . \\
         --skip-blat \\
+        $single_end \\
         $args
 
     mv final-list_candidate-fusion-genes.txt ${prefix}.fusioncatcher.fusion-genes.txt


### PR DESCRIPTION
Addresses https://github.com/nf-core/rnafusion/issues/244
The option `--single-end` is now possible with FusionCatcher, the table in README is updated with a warning that paired-end reds are preferred

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
