### PR TITLE
Fusioninspector standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--fusioninspector_only` parameter to run FusionInspector standalone feeding gene list manually with parameter `--fusioninspector_fusions PATH`
+
 ### Changed
 
 - Arriba use ensembl references-built starindex independently of starfusion_build parameter

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -118,12 +118,12 @@ process {
     }
 
     withName: PICARD_COLLECTRNASEQMETRICS {
-        ext.when         = { !params.skip_qc && (params.starfusion || params.all) }
+        ext.when         = { !params.skip_qc && !params.fusioninspector_only && (params.starfusion || params.all) }
 
     }
 
     withName: PICARD_MARKDUPLICATES {
-        ext.when         = { !params.skip_qc && (params.starfusion || params.all) }
+        ext.when         = { !params.skip_qc && !params.fusioninspector_only && (params.starfusion || params.all) }
     }
 
     withName: PIZZLY {
@@ -136,7 +136,7 @@ process {
     }
 
     withName: QUALIMAP_RNASEQ {
-        ext.when         = { !params.skip_qc && (params.starfusion || params.all)}
+        ext.when         = { !params.skip_qc && !params.fusioninspector_only && (params.starfusion || params.all)}
     }
 
     withName: SAMPLESHEET_CHECK {
@@ -156,7 +156,7 @@ process {
     }
 
     withName: SAMTOOLS_INDEX_FOR_QC {
-        ext.when         = { !params.skip_qc && (params.starfusion || params.all)}
+        ext.when         = { !params.skip_qc && !params.fusioninspector_only && (params.starfusion || params.all)}
         publishDir = [
             path: { "${params.outdir}/samtools_index_for_qc" },
             mode: params.publish_dir_mode,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,9 +72,26 @@ Alternatively, to run only a specific detection tool specify with `--tool`:
 
 ```bash
 nextflow run nf-core/rnafusion \
-  --<tool> \
+  --<toolA> --<toolB> \
   --input <SAMPLE_SHEET.CSV> \
   --outdir <PATH>
+```
+
+#### Running FusionInspector only
+
+FusionInspector can be run standalone with:
+```bash
+nextflow run nf-core/rnafusion \
+  --fusioninspector_only \
+  --fusioninspector_fusion <PATH_TO_CUSTOM_FUSION_FILE>
+  --input <SAMPLE_SHEET.CSV> \
+  --outdir <PATH>
+```
+
+The custom fusion file should have the following format:
+```
+GENE1--GENE2
+GENE3--GENE3
 ```
 
 #### Optional manual feed-in of fusion files

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,6 +80,7 @@ nextflow run nf-core/rnafusion \
 #### Running FusionInspector only
 
 FusionInspector can be run standalone with:
+
 ```bash
 nextflow run nf-core/rnafusion \
   --fusioninspector_only \
@@ -89,6 +90,7 @@ nextflow run nf-core/rnafusion \
 ```
 
 The custom fusion file should have the following format:
+
 ```
 GENE1--GENE2
 GENE3--GENE3

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,6 +46,7 @@ params {
     starindex                  = false
     starfusion                 = false
     fusionreport               = false
+    fusioninspector_only       = false
 
     // Skip steps
     skip_qc                    = false
@@ -70,6 +71,7 @@ params {
     squid_fusions                 = null
     starfusion_fusions            = null
     fusioncatcher_fusions         = null
+    fusioninspector_fusions       = null
 
     // Boilerplate options
     outdir                            = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -139,6 +139,16 @@
                     "fa_icon": "far fa-file-code",
                     "description": "Feed filtered fusionreport fusions to fusioninspector"
                 },
+                "fusioninspector_only": {
+                    "type": "boolean",
+                    "fa_icon": "far fa-file-code",
+                    "description": "Skip fusion-report. --fusioninspector_fusions PATH needed to provide a fusion list as input"
+                },
+                "fusioninspector_fusions": {
+                    "type": "string",
+                    "fa_icon": "far fa-file-code",
+                    "description": "Path to a fusion list file built with format GENE1--GENE2"
+                },
                 "fusionreport": {
                     "type": "boolean",
                     "fa_icon": "far fa-file-code",

--- a/subworkflows/local/arriba_workflow.nf
+++ b/subworkflows/local/arriba_workflow.nf
@@ -18,7 +18,7 @@ workflow ARRIBA_WORKFLOW {
         ch_versions = Channel.empty()
         ch_dummy_file = file("$baseDir/assets/dummy_file_arriba.txt", checkIfExists: true)
 
-        if (params.arriba || params.all) {
+        if ((params.arriba || params.all) && !params.fusioninspector_only) {
 
             STAR_FOR_ARRIBA( reads, ch_starindex_ref, ch_gtf, params.star_ignore_sjdbgtf, params.seq_platform, params.seq_center )
             ch_versions = ch_versions.mix(STAR_FOR_ARRIBA.out.versions)

--- a/subworkflows/local/fusioncatcher_workflow.nf
+++ b/subworkflows/local/fusioncatcher_workflow.nf
@@ -10,7 +10,7 @@ workflow FUSIONCATCHER_WORKFLOW {
         ch_versions = Channel.empty()
         ch_dummy_file = file("$baseDir/assets/dummy_file_fusioncatcher.txt", checkIfExists: true)
 
-        if (params.fusioncatcher || params.all) {
+        if ((params.fusioncatcher || params.all) && !params.fusioninspector_only) {
             if (params.fusioncatcher_fusions){
                 ch_fusioncatcher_fusions = GET_META(reads, params.fusioncatcher_fusions)
             } else {

--- a/subworkflows/local/fusionreport_workflow.nf
+++ b/subworkflows/local/fusionreport_workflow.nf
@@ -28,8 +28,8 @@ workflow FUSIONREPORT_WORKFLOW {
             ch_fusion_list_filtered = FUSIONREPORT.out.fusion_list_filtered
             ch_versions = ch_versions.mix(FUSIONREPORT.out.versions)
         } else {
-            ch_fusion_list = GET_META(reads,  params.fusioninspector_fusions)
-            ch_fusion_list_filtered  = GET_META(reads, params.fusioninspector_fusions)
+            ch_fusion_list = GET_META(reads, params.fusioninspector_fusions)
+            ch_fusion_list_filtered  = ch_fusion_list
         }
 
     emit:

--- a/subworkflows/local/fusionreport_workflow.nf
+++ b/subworkflows/local/fusionreport_workflow.nf
@@ -1,4 +1,5 @@
-include { FUSIONREPORT }                           from '../../modules/local/fusionreport/detect/main'
+include { FUSIONREPORT      }     from '../../modules/local/fusionreport/detect/main'
+include { GET_META          }     from '../../modules/local/getmeta/main'
 
 
 workflow FUSIONREPORT_WORKFLOW {

--- a/subworkflows/local/fusionreport_workflow.nf
+++ b/subworkflows/local/fusionreport_workflow.nf
@@ -36,7 +36,5 @@ workflow FUSIONREPORT_WORKFLOW {
         versions                 = ch_versions.ifEmpty(null)
         fusion_list              = ch_fusion_list
         fusion_list_filtered     = ch_fusion_list_filtered
-
-
 }
 

--- a/subworkflows/local/fusionreport_workflow.nf
+++ b/subworkflows/local/fusionreport_workflow.nf
@@ -26,8 +26,7 @@ workflow FUSIONREPORT_WORKFLOW {
             ch_fusion_list = FUSIONREPORT.out.fusion_list
             ch_fusion_list_filtered = FUSIONREPORT.out.fusion_list_filtered
             ch_versions = ch_versions.mix(FUSIONREPORT.out.versions)
-        }
-        else {
+        } else {
             ch_fusion_list = GET_META(reads,  params.fusioninspector_fusions)
             ch_fusion_list_filtered  = GET_META(reads, params.fusioninspector_fusions)
         }

--- a/subworkflows/local/fusionreport_workflow.nf
+++ b/subworkflows/local/fusionreport_workflow.nf
@@ -14,20 +14,28 @@ workflow FUSIONREPORT_WORKFLOW {
     main:
         ch_versions = Channel.empty()
 
-        reads_fusions = reads
-        .join(arriba_fusions, remainder: true)
-        .join(pizzly_fusions, remainder: true)
-        .join(squid_fusions, remainder: true)
-        .join(starfusion_fusions, remainder: true)
-        .join(fusioncatcher_fusions, remainder: true)
+        if (!params.fusioninspector_only) {
+            reads_fusions = reads
+            .join(arriba_fusions, remainder: true)
+            .join(pizzly_fusions, remainder: true)
+            .join(squid_fusions, remainder: true)
+            .join(starfusion_fusions, remainder: true)
+            .join(fusioncatcher_fusions, remainder: true)
 
-        FUSIONREPORT( reads_fusions, fusionreport_ref)
-        ch_versions = ch_versions.mix(FUSIONREPORT.out.versions)
+            FUSIONREPORT(reads_fusions, fusionreport_ref)
+            ch_fusion_list = FUSIONREPORT.out.fusion_list
+            ch_fusion_list_filtered = FUSIONREPORT.out.fusion_list_filtered
+            ch_versions = ch_versions.mix(FUSIONREPORT.out.versions)
+        else {
+            ch_fusion_list = GET_META(reads,  params.fusioninspector_fusions)
+            ch_fusion_list_filtered  = GET_META(reads, params.fusioninspector_fusions)
+
+        }
 
     emit:
         versions                 = ch_versions.ifEmpty(null)
-        fusion_list              = FUSIONREPORT.out.fusion_list
-        fusion_list_filtered     = FUSIONREPORT.out.fusion_list_filtered
+        fusion_list              = ch_fusion_list
+        fusion_list_filtered     = ch_fusion_list_filtered
 
 
 }

--- a/subworkflows/local/fusionreport_workflow.nf
+++ b/subworkflows/local/fusionreport_workflow.nf
@@ -26,10 +26,10 @@ workflow FUSIONREPORT_WORKFLOW {
             ch_fusion_list = FUSIONREPORT.out.fusion_list
             ch_fusion_list_filtered = FUSIONREPORT.out.fusion_list_filtered
             ch_versions = ch_versions.mix(FUSIONREPORT.out.versions)
+        }
         else {
             ch_fusion_list = GET_META(reads,  params.fusioninspector_fusions)
             ch_fusion_list_filtered  = GET_META(reads, params.fusioninspector_fusions)
-
         }
 
     emit:

--- a/subworkflows/local/pizzly_workflow.nf
+++ b/subworkflows/local/pizzly_workflow.nf
@@ -12,7 +12,7 @@ workflow PIZZLY_WORKFLOW {
         ch_versions = Channel.empty()
         ch_dummy_file = file("$baseDir/assets/dummy_file_pizzly.txt", checkIfExists: true)
 
-        if (params.pizzly || params.all) {
+        if ((params.pizzly || params.all) && !params.fusioninspector_only) {
             if (params.pizzly_fusions) {
                 ch_pizzly_fusions = GET_META(reads, params.pizzly_fusions)
             } else {

--- a/subworkflows/local/squid_workflow.nf
+++ b/subworkflows/local/squid_workflow.nf
@@ -17,7 +17,7 @@ workflow SQUID_WORKFLOW {
         ch_versions = Channel.empty()
         ch_dummy_file = file("$baseDir/assets/dummy_file_squid.txt", checkIfExists: true)
 
-        if (params.squid || params.all) {
+        if ((params.squid || params.all) && !params.fusioninspector_only) {
             if (params.squid_fusions){
                 ch_squid_fusions = GET_META(reads, params.squid_fusions)
             } else {

--- a/subworkflows/local/starfusion_workflow.nf
+++ b/subworkflows/local/starfusion_workflow.nf
@@ -13,7 +13,7 @@ workflow STARFUSION_WORKFLOW {
         ch_align = Channel.empty()
         ch_dummy_file = file("$baseDir/assets/dummy_file_starfusion.txt", checkIfExists: true)
 
-        if (params.starfusion || params.all){
+        if ((params.starfusion || params.all) && !params.fusioninspector_only) {
             if (params.starfusion_fusions){
                 ch_starfusion_fusions = GET_META(reads, params.starfusion_fusions)
             } else {

--- a/workflows/rnafusion.nf
+++ b/workflows/rnafusion.nf
@@ -12,7 +12,7 @@ WorkflowRnafusion.initialise(params, log)
 // Check mandatory parameters
 
 if (file(params.input).exists() || params.build_references) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet does not exist or was not specified!' }
-
+if (params.fusioninspector_only && !params.fusioninspector_fusions) { exit 1, 'Parameter --fusioninspector_fusions PATH_TO_FUSION_LIST expected with parameter --fusioninspector_only'}
 
 ch_chrgtf = params.starfusion_build ? file(params.chrgtf) : file("${params.starfusion_ref}/ref_annot.gtf")
 ch_starindex_ref = params.starfusion_build ? params.starindex_ref : "${params.starfusion_ref}/ref_genome.fa.star.idx"


### PR DESCRIPTION
Adding a `--fusioninspector_only` option. Closes https://github.com/nf-core/rnafusion/issues/234

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/rnafusion _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
