### PR TITLE
Fusion report patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - multiQC updated to 1.13a in process dumpsoftwareversion
 - Updated nf-core and local modules with stub options
+- Patch fusion-report version with fixed mittelman DB and DB extraction date written into software_version.yaml
 
 ### Fixed
 

--- a/modules/local/fusionreport/detect/main.nf
+++ b/modules/local/fusionreport/detect/main.nf
@@ -5,8 +5,8 @@ process FUSIONREPORT {
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda (params.enable_conda ? 'bioconda::star=2.7.9a' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker.io/rannickscilifelab/fusion-report:2.1.5updated' :
-        'docker.io/rannickscilifelab/fusion-report:2.1.5updated' }"
+        'docker.io/rannickscilifelab/fusion-report:2.1.5patched' :
+        'docker.io/rannickscilifelab/fusion-report:2.1.5patched' }"
 
 
     input:

--- a/modules/local/fusionreport/detect/main.nf
+++ b/modules/local/fusionreport/detect/main.nf
@@ -5,8 +5,8 @@ process FUSIONREPORT {
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda (params.enable_conda ? 'bioconda::star=2.7.9a' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker.io/rannickscilifelab/fusion-report:2.1.5patched' :
-        'docker.io/rannickscilifelab/fusion-report:2.1.5patched' }"
+        'docker.io/clinicalgenomics/fusion-report:2.1.5patched' :
+        'docker.io/clinicalgenomics/fusion-report:2.1.5patched' }"
 
 
     input:

--- a/modules/local/fusionreport/detect/main.nf
+++ b/modules/local/fusionreport/detect/main.nf
@@ -38,6 +38,7 @@ process FUSIONREPORT {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         fusion_report: \$(fusion_report --version | sed 's/fusion-report //')
+        fusion_report DB retrieval: \$(cat $fusionreport_ref/DB-timestamp.txt)
     END_VERSIONS
     """
 }

--- a/modules/local/fusionreport/download/main.nf
+++ b/modules/local/fusionreport/download/main.nf
@@ -5,8 +5,8 @@ process FUSIONREPORT_DOWNLOAD {
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda (params.enable_conda ? 'bioconda::star=2.7.9a' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker.io/rannickscilifelab/fusion-report:2.1.5updated' :
-        'docker.io/rannickscilifelab/fusion-report:2.1.5updated' }"
+        'docker.io/rannickscilifelab/fusion-report:2.1.5patched' :
+        'docker.io/rannickscilifelab/fusion-report:2.1.5patched' }"
 
 
     input:

--- a/modules/local/fusionreport/download/main.nf
+++ b/modules/local/fusionreport/download/main.nf
@@ -5,8 +5,8 @@ process FUSIONREPORT_DOWNLOAD {
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda (params.enable_conda ? 'bioconda::star=2.7.9a' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker.io/rannickscilifelab/fusion-report:2.1.5patched' :
-        'docker.io/rannickscilifelab/fusion-report:2.1.5patched' }"
+        'docker.io/clinicalgenomics/fusion-report:2.1.5patched' :
+        'docker.io/clinicalgenomics/fusion-report:2.1.5patched' }"
 
 
     input:


### PR DESCRIPTION
Update fusion-report with a patch that solves the empty mittelman DB issue and outputs a timestamp of when fusion-report DBs have been extracted

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
  - [x] If necessary, also make a PR on the nf-core/rnafusion _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
