### PR TITLE
Fix ref build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed `--fusioninspector_filter` and `--fusionreport_filter` in favor of `--tools_cutoff` (default = 1, no filters applied) [#389](https://github.com/nf-core/rnafusion/pull/389)
+- Now publishing convert2bed output to convert2bed to keep the output file for mosdepth [#420](https://github.com/nf-core/rnafusion/pull/420)
+- No more checks for existence of samplesheet, which made building references fail (building references uses a fake sample sheet if none is provided) [#420](https://github.com/nf-core/rnafusion/pull/420)
 
 ### Fixed
 
 - Fix channel i/o issue in StringTie workflow and add StringTie in github CI tests [#416](https://github.com/nf-core/rnafusion/pull/416)
+- Updated COSMIC database to fix 404 error while downloading fusionreport references [#420](https://github.com/nf-core/rnafusion/pull/420)
 
 ### Removed
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -45,6 +45,14 @@ process {
         ]
     }
 
+    withName: CONVERT2BED {
+        publishDir = [
+            path: { "${params.genomes_base}/convert2bed" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },
@@ -176,11 +184,6 @@ process {
 
     withName: QUALIMAP_RNASEQ {
         ext.when         = { !params.skip_qc && !params.fusioninspector_only && (params.starfusion || params.all)}
-    }
-
-    withName: REFORMAT {
-        ext.args = "forcetrimright=75"
-        ext.args2 = "forcetrimleft=75"
     }
 
     withName: SAMPLESHEET_CHECK {

--- a/modules/local/fusionreport/detect/main.nf
+++ b/modules/local/fusionreport/detect/main.nf
@@ -4,7 +4,7 @@ process FUSIONREPORT {
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda "bioconda::star=2.7.9a"
-    container "docker.io/clinicalgenomics/fusion-report:2.1.5p4"
+    container "docker.io/clinicalgenomics/fusion-report:2.1.5p5"
 
 
     input:

--- a/modules/local/fusionreport/download/main.nf
+++ b/modules/local/fusionreport/download/main.nf
@@ -4,7 +4,7 @@ process FUSIONREPORT_DOWNLOAD {
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda "bioconda::star=2.7.9a"
-    container "docker.io/clinicalgenomics/fusion-report:2.1.5p4"
+    container "docker.io/clinicalgenomics/fusion-report:2.1.5p5"
 
     input:
     val(username)

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,7 +10,7 @@
 params {
 
     // Input options
-    input                      = "fake_input_to_build_refs.csv"
+    input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/rnafusion/testdata/human/samplesheet_valid.csv' // a valid samplesheet has to be present for parameter validation when building references
     build_references           = false
     cosmic_username            = null
     cosmic_passwd              = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,7 +10,7 @@
 params {
 
     // Input options
-    input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/rnafusion/testdata/human/samplesheet_valid.csv' // a valid samplesheet has to be present for parameter validation when building references
+    input                      = "fake_input_to_build_refs.csv"
     build_references           = false
     cosmic_username            = null
     cosmic_passwd              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -32,7 +32,6 @@
                 "input": {
                     "type": "string",
                     "format": "file-path",
-                    "exists": true,
                     "mimetype": "text/csv",
                     "pattern": "^\\S+\\.csv$",
                     "description": "Path to comma-separated file containing information about the samples in the experiment.",


### PR DESCRIPTION
Here as small fixes that were affecting building references:
- fusionreport cosmic database was outdated -> updated to 2.1.5p5
- the check for existence of the samplesheet was removed. As one usually build references without providing a samplesheet, this was causing an error
- removing a REFORMAT config in modules.conf that was still there even thought the harsh trimming was removed

Local tests pass.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/rnafusion _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
