### PR TITLE
add conditions for collectinsertsize running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix channel i/o issue in StringTie workflow and add StringTie in github CI tests [#416](https://github.com/nf-core/rnafusion/pull/416)
 - Updated COSMIC database to fix 404 error while downloading fusionreport references [#420](https://github.com/nf-core/rnafusion/pull/420)
+- Add 'when' condition to run collectinsertsize [#444](https://github.com/nf-core/rnafusion/pull/444)
 
 ### Removed
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -165,6 +165,7 @@ process {
     }
 
     withName: PICARD_COLLECTINSERTSIZEMETRICS {
+        ext.when         = { !params.skip_qc && !params.fusioninspector_only && (params.starfusion || params.all) }
         ext.prefix       = { "${meta.id}_collectinsertsize"}
         publishDir = [
             path: { "${params.outdir}/picard" },


### PR DESCRIPTION
Before this fix, collectinsertsize was started even if starfusion is not run -> no bam file is available


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnafusion _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
