### PR TITLE
fix logical gate: when stringtie and not starfusion, only alignment i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix VCF_COLLECT handling when a tool is absent from FUSIONREPORT report [#458](https://github.com/nf-core/rnafusion/pull/458)
 - fix VCF_COLLECT when fusioninspector output is empty but fusionreport is not [#465](https://github.com/nf-core/rnafusion/pull/465)
 - fix VCF_COLLECT bug [#481](https://github.com/nf-core/rnafusion/pull/481)
+- fix conda package for starfusion/detect[#482](https://github.com/nf-core/rnafusion/pull/482)
+- fix logical gate so when stringtie should run but not starfusion, starfusion will not run[#482](https://github.com/nf-core/rnafusion/pull/482)
 
 ### Removed
 

--- a/modules/local/starfusion/detect/main.nf
+++ b/modules/local/starfusion/detect/main.nf
@@ -2,7 +2,7 @@ process STARFUSION {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::dfam=3.3 bioconda::hmmer=3.3.2 bioconda::star-fusion=1.12.0 bioconda::=2.13.2 bioconda::samtools=1.9 bioconda::star=2.7.8a"
+    conda "bioconda::dfam=3.3 bioconda::hmmer=3.3.2 bioconda::star-fusion=1.12.0 bioconda::trinity=2.13.2 bioconda::samtools=1.9 bioconda::star=2.7.8a"
     container 'docker.io/trinityctat/starfusion:1.12.0'
 
     input:

--- a/subworkflows/local/starfusion_workflow.nf
+++ b/subworkflows/local/starfusion_workflow.nf
@@ -30,6 +30,7 @@ workflow STARFUSION_WORKFLOW {
                 SAMTOOLS_INDEX_FOR_STARFUSION(STAR_FOR_STARFUSION.out.bam_sorted)
                 ch_versions = ch_versions.mix(SAMTOOLS_INDEX_FOR_STARFUSION.out.versions)
                 bam_sorted_indexed = STAR_FOR_STARFUSION.out.bam_sorted.join(SAMTOOLS_INDEX_FOR_STARFUSION.out.bai)
+                reads_junction = reads.join(STAR_FOR_STARFUSION.out.junction )
 
                 if (params.cram.contains('starfusion')){
                     SAMTOOLS_VIEW_FOR_STARFUSION (bam_sorted_indexed, ch_fasta, [] )
@@ -38,12 +39,12 @@ workflow STARFUSION_WORKFLOW {
                     SAMTOOLS_INDEX_FOR_STARFUSION_CRAM (SAMTOOLS_VIEW_FOR_STARFUSION.out.cram)
                     ch_versions = ch_versions.mix(SAMTOOLS_INDEX_FOR_STARFUSION_CRAM.out.versions)
                 }
-                reads_junction = reads.join(STAR_FOR_STARFUSION.out.junction )
+                if (params.starfusion || params.all){
+                    STARFUSION( reads_junction, params.starfusion_ref)
+                    ch_versions = ch_versions.mix(STARFUSION.out.versions)
+                    ch_starfusion_fusions = STARFUSION.out.fusions
+                }
 
-                STARFUSION( reads_junction, params.starfusion_ref)
-                ch_versions = ch_versions.mix(STARFUSION.out.versions)
-
-                ch_starfusion_fusions = STARFUSION.out.fusions
                 ch_star_stats = STAR_FOR_STARFUSION.out.log_final
                 ch_star_gene_count = STAR_FOR_STARFUSION.out.read_per_gene_tab
             }


### PR DESCRIPTION
fix logical gate:
When stringtie should have run, but not starfusion, starfusion ran anyways


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnafusion _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
