### PR TITLE
Fix bug in `FUSIONREPORT_DOWNLOAD` when using `--no_cosmic`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           -stub --build_references \
           --outdir /home/runner/work/rnafusion/rnafusion/results --all \
           --genomes_base /home/runner/work/rnafusion/rnafusion/results/references \
-          --cosmic_username ${{ secrets.COSMIC_USERNAME }} --cosmic_passwd ${{ secrets.COSMIC_PASSWD }}
+          --no_cosmic
 
       - name: "Run pipeline with test data ${{ matrix.NXF_VER }} | ${{ matrix.test_name }} | ${{ matrix.profile }}"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed some Nextflow run-commands in the docs [#491](https://github.com/nf-core/rnafusion/pull/491)
 - Fixed bug when trying to build indices behind a proxy and wget was unable to download arriba indices [#495](https://github.com/nf-core/rnafusion/issues/495)
+- Fixed bug in `FUSIONREPORT_DOWNLOAD` when building references with `--no_cosmic parameter` [#555](https://github.com/nf-core/rnafusion/issues/555)
 
 ### Removed
 

--- a/subworkflows/local/utils_nfcore_rnafusion_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnafusion_pipeline/main.nf
@@ -156,6 +156,11 @@ workflow PIPELINE_COMPLETION {
 //
 def validateInputParameters() {
     genomeExistsError()
+
+    if (params.build_references && params.no_cosmic) {
+            log.warn("No cosmic credentials were provided. Skipping `FUSIONREPORT_DOWNLOAD`")
+    }
+
 }
 
 //

--- a/workflows/build_references.nf
+++ b/workflows/build_references.nf
@@ -76,7 +76,7 @@ workflow BUILD_REFERENCES {
     } else {
         UCSC_GTFTOGENEPRED(STARFUSION_DOWNLOAD.out.chrgtf)
     }
-    if (params.fusionreport || params.all) {
+    if ((params.fusionreport || params.all) && !params.no_cosmic) {
         FUSIONREPORT_DOWNLOAD( params.cosmic_username, params.cosmic_passwd )
     }
 


### PR DESCRIPTION
Closes #557.
Additionally, added the `--no_cosmic` flag to tests in CI.
<!--
# nf-core/rnafusion pull request

Many thanks for contributing to nf-core/rnafusion!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnafusion _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
<!-- - [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`). -->
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
