### PR TITLE
Allow `FUSIONREPORT_DOWNLOAD` to accept credentials via `ext.args`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed some Nextflow run-commands in the docs [#491](https://github.com/nf-core/rnafusion/pull/491)
 - Fixed bug when trying to build indices behind a proxy and wget was unable to download arriba indices [#495](https://github.com/nf-core/rnafusion/issues/495)
 - Fixed bug in `FUSIONREPORT_DOWNLOAD` when building references with `--no_cosmic parameter` [#555](https://github.com/nf-core/rnafusion/issues/555)
+- Refactor structure in `FUSIONREPORT_DOWNLOAD` to use cosmic credentials in `ext.args` [#556](https://github.com/nf-core/rnafusion/issues/556)
 
 ### Removed
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -107,7 +107,7 @@ process {
     }
 
     withName: 'FUSIONREPORT_DOWNLOAD' {
-        ext.args         = { {params.no_cosmic} ? "--no-cosmic" : "" }
+        ext.args         = { {params.no_cosmic} ? "--no-cosmic" : " --cosmic_usr ${params.cosmic_username} --cosmic_passwd ${params.cosmic_passwd}" }
         ext.args2        = { params.qiagen ? "--qiagen" : "" }
         publishDir = [
             path: { "${params.genomes_base}/fusion_report_db" },

--- a/modules/local/fusionreport/download/main.nf
+++ b/modules/local/fusionreport/download/main.nf
@@ -5,10 +5,6 @@ process FUSIONREPORT_DOWNLOAD {
     conda "bioconda::star=2.7.9a"
     container "docker.io/clinicalgenomics/fusion-report:3.1.0"
 
-    input:
-    val(username)
-    val(passwd)
-
     output:
     path "*"                , emit: reference
     path "versions.yml"     , emit: versions
@@ -17,7 +13,7 @@ process FUSIONREPORT_DOWNLOAD {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args ?: ''
     """
-    fusion_report download --cosmic_usr "$username" --cosmic_passwd "$passwd" $args ./
+    fusion_report download $args ./
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/subworkflows/local/utils_nfcore_rnafusion_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnafusion_pipeline/main.nf
@@ -158,7 +158,7 @@ def validateInputParameters() {
     genomeExistsError()
 
     if (params.build_references && params.no_cosmic) {
-            log.warn("No cosmic credentials were provided. Skipping `FUSIONREPORT_DOWNLOAD`")
+            log.warn("No cosmic credentials were provided. Skipping COSMIC DB download from `FUSIONREPORT_DOWNLOAD`")
     }
 
 }

--- a/workflows/build_references.nf
+++ b/workflows/build_references.nf
@@ -76,8 +76,8 @@ workflow BUILD_REFERENCES {
     } else {
         UCSC_GTFTOGENEPRED(STARFUSION_DOWNLOAD.out.chrgtf)
     }
-    if ((params.fusionreport || params.all) && !params.no_cosmic) {
-        FUSIONREPORT_DOWNLOAD( params.cosmic_username, params.cosmic_passwd )
+    if (params.fusionreport || params.all) {
+        FUSIONREPORT_DOWNLOAD()
     }
 
 }


### PR DESCRIPTION
Related to #557 
<!--
# nf-core/rnafusion pull request

Many thanks for contributing to nf-core/rnafusion!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnafusion _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
<!-- - [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`). -->
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
