### PR TITLE
Fix FUSIONREPORT_DOWNLOAD: remove double nested folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated to nf-core/tools 3.0.2 [#504](https://github.com/nf-core/rnafusion/pull/504)
 - Remove local module `RRNA_TRANSCRIPTS` (replaced by nf-core module) [#541](https://github.com/nf-core/rnafusion/pull/541)
 - Allow fastq files without a dot before .fn(.gz)/.fastq(.gz) files [#548](https://github.com/nf-core/rnafusion/pull/548)
+- Remove double nested folder introduced in [#572](https://github.com/nf-core/rnafusion/pull/577), []()
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add nf-test to local module: `FUSIONREPORT_DOWNLOAD` [#560](https://github.com/nf-core/rnafusion/pull/560)
 - Add nf-test to local subworkflow: `QC_WORKFLOW` [#568](https://github.com/nf-core/rnafusion/pull/568)
 - Add nf-test to local subworkflow: `TRIM_WORKFLOW` [#572](https://github.com/nf-core/rnafusion/pull/572)
-- Add nf-test to local module: `FUSIONREPORT_DETECT`. Improve `FUSIONREPORT_DOWNLOAD` module [#572](https://github.com/nf-core/rnafusion/pull/577)
+- Add nf-test to local module: `FUSIONREPORT_DETECT`. Improve `FUSIONREPORT_DOWNLOAD` module [#577](https://github.com/nf-core/rnafusion/pull/577)
 
 ### Changed
 
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated to nf-core/tools 3.0.2 [#504](https://github.com/nf-core/rnafusion/pull/504)
 - Remove local module `RRNA_TRANSCRIPTS` (replaced by nf-core module) [#541](https://github.com/nf-core/rnafusion/pull/541)
 - Allow fastq files without a dot before .fn(.gz)/.fastq(.gz) files [#548](https://github.com/nf-core/rnafusion/pull/548)
-- Remove double nested folder introduced in [#572](https://github.com/nf-core/rnafusion/pull/577), [#581](https://github.com/nf-core/rnafusion/pull/581)
+- Remove double nested folder introduced in [#577](https://github.com/nf-core/rnafusion/pull/577), [#581](https://github.com/nf-core/rnafusion/pull/581)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated to nf-core/tools 3.0.2 [#504](https://github.com/nf-core/rnafusion/pull/504)
 - Remove local module `RRNA_TRANSCRIPTS` (replaced by nf-core module) [#541](https://github.com/nf-core/rnafusion/pull/541)
 - Allow fastq files without a dot before .fn(.gz)/.fastq(.gz) files [#548](https://github.com/nf-core/rnafusion/pull/548)
-- Remove double nested folder introduced in [#572](https://github.com/nf-core/rnafusion/pull/577), []()
+- Remove double nested folder introduced in [#572](https://github.com/nf-core/rnafusion/pull/577), [#581](https://github.com/nf-core/rnafusion/pull/581)
 
 ### Fixed
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -114,7 +114,7 @@ process {
         ext.args         = { {params.no_cosmic} ? "--no-cosmic" : " --cosmic_usr ${params.cosmic_username} --cosmic_passwd ${params.cosmic_passwd}" }
         ext.args2        = { params.qiagen ? "--qiagen" : "" }
         publishDir = [
-            path: { "${params.genomes_base}/fusion_report_db" },
+            path: { "${params.genomes_base}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/modules/local/fusionreport/detect/tests/main.nf.test
+++ b/modules/local/fusionreport/detect/tests/main.nf.test
@@ -33,8 +33,7 @@ nextflow_process {
                     file("https://github.com/Clinical-Genomics/fusion-report/raw/master/tests/test_data/fusioncatcher.txt")
                 ]
 
-                input[1] = FUSIONREPORT_DOWNLOAD.out.fusionreport_db
-
+                input[1] = FUSIONREPORT_DOWNLOAD.out.fusionreport_ref
                 input[2] = 1
                 """
             }
@@ -91,7 +90,7 @@ nextflow_process {
                     file("https://github.com/Clinical-Genomics/fusion-report/raw/master/tests/test_data/fusioncatcher.txt")
                 ]
 
-                input[1] = FUSIONREPORT_DOWNLOAD.out.fusionreport_db
+                input[1] = FUSIONREPORT_DOWNLOAD.out.fusionreport_ref
 
                 input[2] = 1
                 """

--- a/modules/local/fusionreport/detect/tests/main.nf.test.snap
+++ b/modules/local/fusionreport/detect/tests/main.nf.test.snap
@@ -68,7 +68,7 @@
         "content": [
             {
                 "0": [
-                    "versions.yml:md5,8cabeb934dbeb51399427d83c57bf1b4"
+                    "versions.yml:md5,6bd28f2526774f519a7627a30c6a7f2f"
                 ],
                 "1": [
                     [
@@ -173,7 +173,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8cabeb934dbeb51399427d83c57bf1b4"
+                    "versions.yml:md5,6bd28f2526774f519a7627a30c6a7f2f"
                 ]
             }
         ],
@@ -181,6 +181,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.10.2"
         },
-        "timestamp": "2024-12-10T14:55:14.475834"
+        "timestamp": "2024-12-10T15:13:58.414161"
     }
 }

--- a/modules/local/fusionreport/detect/tests/main.nf.test.snap
+++ b/modules/local/fusionreport/detect/tests/main.nf.test.snap
@@ -68,7 +68,7 @@
         "content": [
             {
                 "0": [
-                    "versions.yml:md5,6bd28f2526774f519a7627a30c6a7f2f"
+                    "versions.yml:md5,8cabeb934dbeb51399427d83c57bf1b4"
                 ],
                 "1": [
                     [
@@ -173,7 +173,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,6bd28f2526774f519a7627a30c6a7f2f"
+                    "versions.yml:md5,8cabeb934dbeb51399427d83c57bf1b4"
                 ]
             }
         ],
@@ -181,6 +181,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.10.2"
         },
-        "timestamp": "2024-12-06T13:12:32.981394201"
+        "timestamp": "2024-12-10T14:55:14.475834"
     }
 }

--- a/modules/local/fusionreport/download/main.nf
+++ b/modules/local/fusionreport/download/main.nf
@@ -6,17 +6,17 @@ process FUSIONREPORT_DOWNLOAD {
     container "docker.io/clinicalgenomics/fusion-report:3.1.0"
 
     output:
-    tuple val(meta), path("fusionreport_dbs"), emit: fusionreport_db
+    tuple val(meta), path("fusion_report_db"), emit: fusionreport_ref
     path "versions.yml"                      , emit: versions
 
     script:
-    meta = [id: 'fusionreport_dbs']
+    meta = [id: 'fusion_report_db']
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     """
     fusion_report download $args ./
-    mkdir fusionreport_dbs
-    mv *.txt *.log *.db fusionreport_dbs
+    mkdir fusion_report_db
+    mv *.txt *.log *.db fusion_report_db/
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -25,14 +25,14 @@ process FUSIONREPORT_DOWNLOAD {
     """
 
     stub:
-    meta = [id: 'fusionreport_dbs']
+    meta = [id: 'fusion_report_db']
     """
-    mkdir fusionreport_dbs
-    touch fusionreport_dbs/cosmic.db
-    touch fusionreport_dbs/fusiongdb2.db
-    touch fusionreport_dbs/mitelman.db
-    touch fusionreport_dbs/DB-timestamp.txt
-    touch fusionreport_dbs/fusion_report.log
+    mkdir fusion_report_db
+    touch fusion_report_db/cosmic.db
+    touch fusion_report_db/fusiongdb2.db
+    touch fusion_report_db/mitelman.db
+    touch fusion_report_db/DB-timestamp.txt
+    touch fusion_report_db/fusion_report.log
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/fusionreport/download/tests/main.nf.test
+++ b/modules/local/fusionreport/download/tests/main.nf.test
@@ -19,10 +19,10 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    path(process.out.fusionreport_db[0][1]).resolve("fusiongdb2.db"),
-                    path(process.out.fusionreport_db[0][1]).resolve("mitelman.db"),
-                    path(process.out.fusionreport_db[0][1]).resolve("DB-timestamp.txt").exists(),
-                    path(process.out.fusionreport_db[0][1]).resolve("fusion_report.log").exists(),
+                    path(process.out.fusionreport_ref[0][1]).resolve("fusiongdb2.db"),
+                    path(process.out.fusionreport_ref[0][1]).resolve("mitelman.db"),
+                    path(process.out.fusionreport_ref[0][1]).resolve("DB-timestamp.txt").exists(),
+                    path(process.out.fusionreport_ref[0][1]).resolve("fusion_report.log").exists(),
                     process.out.versions
                     ).match() }
             )

--- a/modules/local/fusionreport/download/tests/main.nf.test.snap
+++ b/modules/local/fusionreport/download/tests/main.nf.test.snap
@@ -21,7 +21,7 @@
                 "0": [
                     [
                         {
-                            "id": "fusionreport_dbs"
+                            "id": "fusion_report_db"
                         },
                         [
                             "DB-timestamp.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -35,10 +35,10 @@
                 "1": [
                     "versions.yml:md5,fa5f13c563f431912048c1802b5a0c74"
                 ],
-                "fusionreport_db": [
+                "fusion_report_db": [
                     [
                         {
-                            "id": "fusionreport_dbs"
+                            "id": "fusion_report_db"
                         },
                         [
                             "DB-timestamp.txt:md5,d41d8cd98f00b204e9800998ecf8427e",

--- a/modules/local/fusionreport/download/tests/main.nf.test.snap
+++ b/modules/local/fusionreport/download/tests/main.nf.test.snap
@@ -35,7 +35,7 @@
                 "1": [
                     "versions.yml:md5,fa5f13c563f431912048c1802b5a0c74"
                 ],
-                "fusion_report_db": [
+                "fusionreport_ref": [
                     [
                         {
                             "id": "fusion_report_db"
@@ -58,6 +58,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.10.2"
         },
-        "timestamp": "2024-12-05T19:35:49.629287874"
+        "timestamp": "2024-12-10T15:05:22.781845"
     }
 }


### PR DESCRIPTION
#577 introduced a double folder structure for fusion_report_db, this PR removes one layer

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnafusion _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
<!-- - [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`). -->
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
