### PR TITLE
fix conda pkg from star to fusion-report and upgrade pkg to 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## v3.0.3 - 2025-02-09
+
+### Added
+
+### Changed
+
+### Fixed
+
+- fix the wrong conda package bug of the fuison-report module
+
 ## v3.0.2 - [2024-04-10]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </h1>
 
 [![GitHub Actions CI Status](https://github.com/nf-core/rnafusion/actions/workflows/ci.yml/badge.svg)](https://github.com/nf-core/rnafusion/actions/workflows/ci.yml)
-[![GitHub Actions Linting Status](https://github.com/nf-core/rnafusion/actions/workflows/linting.yml/badge.svg)](https://github.com/nf-core/rnafusion/actions/workflows/linting.yml)[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/rnafusion/results)[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.XXXXXXX-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.XXXXXXX)
+[![GitHub Actions Linting Status](https://github.com/nf-core/rnafusion/actions/workflows/linting.yml/badge.svg)](https://github.com/nf-core/rnafusion/actions/workflows/linting.yml)[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/rnafusion/results)[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.2565517-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.2565517)
 [![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)
 
 [![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A523.04.0-23aa62.svg)](https://www.nextflow.io/)

--- a/modules/local/fusionreport/detect/main.nf
+++ b/modules/local/fusionreport/detect/main.nf
@@ -2,8 +2,8 @@ process FUSIONREPORT {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::star=2.7.9a"
     container "docker.io/clinicalgenomics/fusion-report:2.1.8"
+    conda "bioconda::fusion-report=3.1.1"
 
 
     input:

--- a/modules/local/fusionreport/detect/main.nf
+++ b/modules/local/fusionreport/detect/main.nf
@@ -2,8 +2,8 @@ process FUSIONREPORT {
     tag "$meta.id"
     label 'process_medium'
 
-    container "docker.io/clinicalgenomics/fusion-report:2.1.8"
     conda "bioconda::fusion-report=3.1.1"
+    container "docker.io/clinicalgenomics/fusion-report:3.1.1"
 
 
     input:

--- a/modules/local/fusionreport/download/main.nf
+++ b/modules/local/fusionreport/download/main.nf
@@ -2,8 +2,8 @@ process FUSIONREPORT_DOWNLOAD {
     tag 'fusionreport'
     label 'process_medium'
 
-    conda "bioconda::star=2.7.9a"
     container "docker.io/clinicalgenomics/fusion-report:2.1.8"
+    conda "bioconda::fusion-report=3.1.1"
 
     input:
     val(username)

--- a/modules/local/fusionreport/download/main.nf
+++ b/modules/local/fusionreport/download/main.nf
@@ -2,8 +2,8 @@ process FUSIONREPORT_DOWNLOAD {
     tag 'fusionreport'
     label 'process_medium'
 
-    container "docker.io/clinicalgenomics/fusion-report:2.1.8"
     conda "bioconda::fusion-report=3.1.1"
+    container "docker.io/clinicalgenomics/fusion-report:3.1.1"
 
     input:
     val(username)


### PR DESCRIPTION
<!--
# nf-core/rnafusion pull request

Many thanks for contributing to nf-core/rnafusion!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
-->

Fix the bug: fusion-report module used the `star` aligner as its `conda` package.
Since no 2.1.8 bioconda package of fusion-report, so upgrade both of them to 3.1.1. 
