### PR TITLE
run_fusioncatcher back to fusioncatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix error message when parameter outdir is missing [#611](https://github.com/nf-core/rnafusion/pull/611)
 - Updated documentation for fusion-report score calculation to reflect 80/20 weight distribution between tool detection and database hits [#620](https://github.com/nf-core/rnafusion/pull/620)
 - Update htslib and samtools version in `star/align` to 1.21 [#634](https://github.com/nf-core/rnafusion/pull/634)
+- `--run_fusioncatcher` back to `fusioncatcher` [#641](https://github.com/nf-core/rnafusion/pull/641)
 
 ### Fixed
 

--- a/subworkflows/local/fusioncatcher_workflow/main.nf
+++ b/subworkflows/local/fusioncatcher_workflow/main.nf
@@ -3,13 +3,13 @@ include { FUSIONCATCHER_DETECT } from '../../../modules/local/fusioncatcher/dete
 // TODO: Remove fusioncatcher_fusions as parameter.
 // TODO: remove dummy file. Work with Channel.empty()
 // TODO: if the files were already produced and the user want to skip the module because of this, they should be taken them from the sample sheet
-// TODO: harmonize `run_fusioncatcher` and `fusioncatcher_only` parameters at main workflow level to activate/skip this one.
+// TODO: harmonize `fusioncatcher` and `fusioncatcher_only` parameters at main workflow level to activate/skip this one.
 
 workflow FUSIONCATCHER_WORKFLOW {
     take:
         reads                   // channel [ meta, [ fastqs ] ]
         fusioncatcher_ref       // channel [ meta, path       ]
-        run_fusioncatcher       // boolean
+        fusioncatcher          // boolean
         all                     // boolean
         fusioninspector_only    // boolean
         fusioncatcher_fusions   // path, string
@@ -18,7 +18,7 @@ workflow FUSIONCATCHER_WORKFLOW {
         ch_versions   = Channel.empty()
         ch_dummy_file = file("$baseDir/assets/dummy_file_fusioncatcher.txt", checkIfExists: true)
 
-        if (( run_fusioncatcher || all) && !fusioninspector_only ) {
+        if (( fusioncatcher || all) && !fusioninspector_only ) {
             if (fusioncatcher_fusions){
 
                 ch_fusioncatcher_fusions = reads.combine(Channel.value(file(fusioncatcher_fusions, checkIfExists:true)))

--- a/workflows/rnafusion.nf
+++ b/workflows/rnafusion.nf
@@ -122,7 +122,7 @@ workflow RNAFUSION {
     FUSIONCATCHER_WORKFLOW (
         ch_reads,
         BUILD_REFERENCES.out.ch_fusioncatcher_ref,       // channel [ meta, path       ]
-        params.run_fusioncatcher,
+        params.fusioncatcher,
         params.all,
         params.fusioninspector_only,
         params.fusioncatcher_fusions


### PR DESCRIPTION
the parameter `run_fusioncatcher` was wrongly introduced in a mixed way to replace `fusioncatcher`. 
here we revert it back to `fusioncatcher` to stay consistent with the other flags for the fusion calling tools

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnafusion/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnafusion _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
<!-- - [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`). -->
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
