### PR TITLE
Update fastq path regex to allow spaces in directory paths.

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -17,15 +17,15 @@
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+f(ast)?q\\.gz$",
-                "errorMessage": "FastQ file for reads 1 must be provided, cannot contain spaces, has to exist and must have extension '.fq.gz' or '.fastq.gz'"
+                "pattern": "^([\\S\\s]*\\/)?[^\\s\\/]+\\.f(ast)?q\\.gz$",
+                "errorMessage": "FastQ file for reads 1 must be provided, cannot contain spaces in filename, has to exist and must have extension '.fq.gz' or '.fastq.gz'"
             },
             "fastq_2": {
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+f(ast)?q\\.gz$",
-                "errorMessage": "FastQ file for reads 2 cannot contain spaces, has to exist and must have extension '.fq.gz' or '.fastq.gz'"
+                "pattern": "^([\\S\\s]*\\/)?[^\\s\\/]+\\.f(ast)?q\\.gz$",
+                "errorMessage": "FastQ file for reads 2 cannot contain spaces in filename, has to exist and must have extension '.fq.gz' or '.fastq.gz'"
             },
             "bam": {
                 "type": "string",


### PR DESCRIPTION
At present, the regular expression that defines the allowable values in fastq_1 and fastq_2 columns of the spreadsheet excludes reads that contain spaces anywhere in the path.

While it's certainly try that best-practice is to remove spaces from paths, in some circumstances this can be difficult. If you're working with a large directory on object storage, for example. Renaming a directory is not an atomic operation and can take many hours.

I think it is sensible to prevent users using reads with spaces in the filename `/path/to/my reads.fastq.gz`, but spaces in the directory path `/path/to/my project/and/some/reads.fastq.gz` are fine. Nextflow will stage them into the work directory anyway, so no workflow tools are going to see those paths.

To validate that the regular expression works, you can open `nextflow console` and run this snippet:

```groovy
def regex = ~/^([\S\s]*\/)?[^\s\/]+\.f(ast)?q\.gz$/

// Example list of paths
def paths = [
    "s3://path/to some/reads/RD-172.fastq.gz",   // valid
    "reads.fq.gz",                               // valid
    "reads.fastq.gz",                            // valid
    "path/reads.fastq.gz",                       // valid
    "path with space/reads.fastq.gz",            // valid
    "path/to some/reads.fq.gz",                  // valid
    "path/reads .fastq.gz",                      // invalid (space in filename)
    "path/reads.fastq",                          // invalid (missing .gz)
    "reads.fastq .gz"                            // invalid (space in filename)
]

// Validate each path
paths.each { path ->
    if (path ==~ regex) {
        println "VALID:   $path"
    } else {
        println "INVALID: $path"
    }
}
```
