### PR TITLE
Add creation of missing output files to CTAT-SPLICING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing memory unit for fusioncatcher [#674](https://github.com/nf-core/rnafusion/pull/674)
 - Fix fusioncatcher download link [#693](https://github.com/nf-core/rnafusion/pull/693)
 - Fix fusionreport singularity container [#713](https://github.com/nf-core/rnafusion/pull/713)
+- Fix CTAT-SPLICING output when no cancer introns were found [#722](https://github.com/nf-core/rnafusion/pull/722)
 
 ### Removed
 

--- a/modules/local/ctatsplicing/startocancerintrons/main.nf
+++ b/modules/local/ctatsplicing/startocancerintrons/main.nf
@@ -42,7 +42,7 @@ process CTATSPLICING_STARTOCANCERINTRONS {
         ${args}
 
     # Create the missing outputs when no cancer introns are found
-    if [ $? -eq 0 ]; then
+    if [ \$? -eq 0 ]; then
         touch ${prefix}.cancer_intron_reads.sorted.bam
         touch ${prefix}.cancer_intron_reads.sorted.bam.bai
         touch ${prefix}.gene_reads.sorted.sifted.bam


### PR DESCRIPTION
CTAT-SPLICING doesn't create some outputs when no cancer introns have been found. This fixes that issue