### PR TITLE
Reorganizes the schema

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -128,8 +128,7 @@
                     "exists": true,
                     "pattern": "\\S+\\.f(n|ast)?a$",
                     "description": "Path to adapter fasta file: default: []",
-                    "fa_icon": "fas fa-cut",
-                    "default": "[]"
+                    "fa_icon": "fas fa-cut"
                 },
                 "save_trimmed_fail": {
                     "type": "boolean",


### PR DESCRIPTION
This PR aims to improve the order of the Nextflow schema by reorganizing sections and adding defaults for enhanced readability.

  Changes

  - Reorganized schema sections: Moved input_output_options to the top for better visibility
  - Added defaults to required parameters:
    - genomes_base: s3://nf-core-awsmegatests/rnafusion/references
    - genome_gencode_version: 46
    - genome: GRCh38
  - Consolidated options: Merged compression_options into alignment_options and add additional alignment related parameters
  - Move all reference related inputs to the reference section