### PR TITLE
make fasta input of star a value channel

### DIFF
--- a/workflows/rnafusion.nf
+++ b/workflows/rnafusion.nf
@@ -207,7 +207,7 @@ workflow RNAFUSION {
         def ch_star_junctions        = ch_input.junctions.filter { meta, file -> file && !meta.align }
         def ch_star_splice_junctions = ch_input.splice_junctions.filter { meta, file -> file && !meta.align }
         if(tools.intersect(["ctatsplicing", "arriba", "starfusion", "stringtie"])) {
-            def ch_fasta_fai = BUILD_REFERENCES.out.fasta.join(BUILD_REFERENCES.out.fai, failOnMismatch:true, failOnDuplicate:true)
+            def ch_fasta_fai = BUILD_REFERENCES.out.fasta.join(BUILD_REFERENCES.out.fai, failOnMismatch:true, failOnDuplicate:true).collect()
 
             FASTQ_ALIGN_STAR(
                 ch_fastqs_to_align,


### PR DESCRIPTION
This fixes an issue where the postprocessing parts in fastq_align_star are only run once